### PR TITLE
Fixes display of max soul shards on the sphere — now depends on config

### DIFF
--- a/Necrosis.lua
+++ b/Necrosis.lua
@@ -2512,10 +2512,14 @@ function Necrosis:BagExplore(arg)
 		if NecrosisConfig.CountType == 2 then
 			NecrosisShardCount:SetText(Local.Reagent.Infernal.." / "..Local.Reagent.Demoniac)
 		elseif NecrosisConfig.CountType == 1 then
-			if Local.Soulshard.Count < 10 then
-				NecrosisShardCount:SetText("0"..Local.Soulshard.Count)
+			if NecrosisConfig.DestroyShard then
+				if Local.Soulshard.Count < 10 then
+					NecrosisShardCount:SetText("0"..Local.Soulshard.Count.."/"..NecrosisConfig.DestroyCount)
+				else
+					NecrosisShardCount:SetText(Local.Soulshard.Count.."/"..NecrosisConfig.DestroyCount)
+				end
 			else
-				NecrosisShardCount:SetText(Local.Soulshard.Count.."/"..NecrosisConfig.DestroyCount)
+				NecrosisShardCount:SetText(Local.Soulshard.Count)
 			end
 		end
 	else

--- a/Necrosis.lua
+++ b/Necrosis.lua
@@ -2512,15 +2512,7 @@ function Necrosis:BagExplore(arg)
 		if NecrosisConfig.CountType == 2 then
 			NecrosisShardCount:SetText(Local.Reagent.Infernal.." / "..Local.Reagent.Demoniac)
 		elseif NecrosisConfig.CountType == 1 then
-			if NecrosisConfig.DestroyShard then
-				if Local.Soulshard.Count < 10 then
-					NecrosisShardCount:SetText("0"..Local.Soulshard.Count.."/"..NecrosisConfig.DestroyCount)
-				else
-					NecrosisShardCount:SetText(Local.Soulshard.Count.."/"..NecrosisConfig.DestroyCount)
-				end
-			else
-				NecrosisShardCount:SetText(Local.Soulshard.Count)
-			end
+			NecrosisShardCount:SetText((Local.Soulshard.Count < 10 and "0" or "") .. Local.Soulshard.Count .. (NecrosisConfig.DestroyShard and "/"..NecrosisConfig.DestroyCount or ""))
 		end
 	else
 		NecrosisShardCount:SetText("")


### PR DESCRIPTION
Regards "Maximum number of shards to keep" option — 
— currently the number is always displayed on the sphere even if the option is turned off.
_(like '04/20' where 04 is the number of shards in bag, and 20 is the mentioned max number)_

I think, the second number is unnecessary on the sphere when the option is turned off.
If I don't want to limit my shards, there is no need to _always_ see this maximum number.

This fixes it — now displays just the number of shards in bag if the option for max number of shards is turned off.

P.S.
The better way would be adding the option like "Always show maximum number of shards to keep", I leave it to someone else.